### PR TITLE
fix: delegate tag validation to compare-versions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,12 +27,6 @@ function getConfig(path) {
   return DEFAULT_CONFIG;
 }
 
-const TAG_REGEX = /^v?(\d+).(\d+).(\d+)$/i;
-
-function validateTag(tag) {
-  return TAG_REGEX.test(tag);
-}
-
 async function run() {
   const token = getInput("token", { required: true });
   const octokit = getOctokit(token);
@@ -53,7 +47,7 @@ async function run() {
   });
 
   const validSortedTags = tags
-    .filter((t) => validateTag(t.name))
+    .filter((t) => compareVersions.validate(t.name))
     .sort((a, b) => {
       return compareVersions(a.name, b.name);
     })


### PR DESCRIPTION
- In our case all tags do not conform to `v*.*.*`; we have some of them (revisions) that include letters at the end and so they get disregarded as a "previous tag".
- `compare-versions` actually [supports the full semver spec](https://github.com/omichelsen/compare-versions/blob/master/index.js#L13), so we can delegate the tag validation to allow everything they can use for comparison.