### PR TITLE
feat: Allow to create changelog on first tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,8 +52,23 @@ async function run() {
       return compareVersions(a.name, b.name);
     })
     .reverse();
-
-  if (validSortedTags.length < 2) {
+  
+  // if there is only one tag, then create a changelog from the first commit
+  let base = null;
+  let head = null;
+  if (validSortedTags.length > 1) {
+    base = validSortedTags[1].commit.sha;
+    head = validSortedTags[0].commit.sha;
+  } else if (validSortedTags.length === 1) {
+    const { data: commits } = await octokit.rest.repos.listCommits({
+      owner,
+      repo,
+      per_page: 1,
+    });
+    const firstCommit = commits[0];
+    base = firstCommit.sha;
+    head = validSortedTags[0].commit.sha;
+  } else {
     setFailed("Couldn't find previous tag");
     return;
   }
@@ -62,8 +77,8 @@ async function run() {
   const result = await octokit.rest.repos.compareCommits({
     owner,
     repo,
-    base: validSortedTags[1].commit.sha,
-    head: validSortedTags[0].commit.sha,
+    base: base,
+    head: head
   });
 
   const fetchUserFunc = async function (pullNumber) {


### PR DESCRIPTION
This addresses #4 
In the case that there's only 1 tag (the first tag) this will build the change list by comparing to the first commit on the repo.

